### PR TITLE
fix heading normalized form warnings

### DIFF
--- a/src/html_tree/html_element.rs
+++ b/src/html_tree/html_element.rs
@@ -46,7 +46,7 @@ fn is_normalised_element_name(name: &str) -> bool {
         | "linearGradient"
         | "radialGradient"
         | "textPath" => true,
-        _ => name.chars().all(|c| c.is_ascii_lowercase()),
+        _ => !name.chars().any(|c| c.is_ascii_uppercase()),
     }
 }
 


### PR DESCRIPTION
fixes #8

reference: https://github.com/yewstack/yew/blob/65d9d654e4f9a53c8885be10303c99b9ee9fcd23/packages/yew-macro/src/html_tree/html_element.rs#L49

note numbers are considered neither uppercase nor lowercase.